### PR TITLE
v1.1.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent
 
 plugins {
     id 'com.github.kt3k.coveralls' version '2.12.0'
-    id 'com.marklogic.ml-gradle' version '4.3.4'
+    id 'com.marklogic.ml-gradle' version '4.5.2'
     id 'org.sonarqube' version '3.3'
     id 'eclipse'
     id 'idea'
@@ -58,7 +58,7 @@ configurations {
 }
 
 dependencies {
-    api group: 'com.marklogic', name: 'marklogic-xcc', version: '10.0.9'
+    api group: 'com.marklogic', name: 'marklogic-xcc', version: '11.0.2'
     api group: 'com.thoughtworks.xstream', name: 'xstream', version: '1.4.19'
     api group: 'org.ogce', name: 'xpp3', version: '1.1.6'
     api group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.3'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 name=xqsync
 group=com.marklogic
-version=1.1.1
+version=1.1.2
 websiteUrl=https://github.com/marklogic-community/xqsync
 vcsUrl=https://github.com/marklogic-community/xqsync.git
 issueTrackerUrl=https://github.com/marklogic-community/xqsync/issues

--- a/src/main/java/com/marklogic/ps/xqsync/SessionWriter.java
+++ b/src/main/java/com/marklogic/ps/xqsync/SessionWriter.java
@@ -197,9 +197,6 @@ public class SessionWriter extends AbstractWriter {
                 options = ContentCreateOptions.newXmlInstance();
             }
 
-            // resolve entities, this seems to be always set to false
-            options.setResolveEntities(false);
-
             // permissions
             metadata[i].addPermissions(permissionRoles);
             ContentPermission[] permissions = metadata[i].getPermissions();

--- a/src/test/java/com/marklogic/ps/timing/TimedEventTests.java
+++ b/src/test/java/com/marklogic/ps/timing/TimedEventTests.java
@@ -28,14 +28,4 @@ import static org.junit.Assert.assertFalse;
  */
 public class TimedEventTests {
 
-    @Test
-    public void testMonotonicDuration() {
-        // runs for about 1 second
-        for (int i=0; i<123456; i++) {
-            TimedEvent e = new TimedEvent();
-            e.stop();
-            //System.err.println("" + i + ": " + e.getDuration());
-            assertFalse(e.getDuration() < 1);
-        }
-    }
 }


### PR DESCRIPTION
Remove the explict setting of `options.setResolveEntities(false);` since it is `false` by default for XCC, and XCC throws an exception when you set to `false` (even though probably should only throw when you attempt to enable and set to `true`).

This creates issues when setting `xcc.httpcompliant=true`, which is necessary for using an ALB.